### PR TITLE
seo: Add canonical URLs to all pages for improved SEO

### DIFF
--- a/src/lib/utils/canonical.ts
+++ b/src/lib/utils/canonical.ts
@@ -1,0 +1,34 @@
+import config from "@/config/config.json";
+
+/**
+ * Generates a canonical URL for a given pathname
+ * @param pathname - The pathname (e.g., "/about", "/providers/aws")
+ * @returns Canonical URL with proper base URL and trailing slash handling
+ */
+export function getCanonicalURL(pathname: string): string {
+  const { base_url, trailing_slash } = config.site;
+  
+  // Normalize pathname - remove leading slash if present
+  const normalizedPath = pathname.startsWith("/") ? pathname.slice(1) : pathname;
+  
+  // Build canonical URL
+  let canonicalURL = `${base_url}/${normalizedPath}`;
+  
+  // Handle trailing slash preference
+  if (trailing_slash && !canonicalURL.endsWith("/") && normalizedPath !== "") {
+    canonicalURL += "/";
+  } else if (!trailing_slash && canonicalURL.endsWith("/") && normalizedPath !== "") {
+    canonicalURL = canonicalURL.slice(0, -1);
+  }
+  
+  return canonicalURL;
+}
+
+/**
+ * Gets canonical URL from Astro.url object
+ * @param astroUrl - Astro.url object from component
+ * @returns Canonical URL
+ */
+export function getCanonicalFromAstroURL(astroUrl: URL): string {
+  return getCanonicalURL(astroUrl.pathname);
+}

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -5,12 +5,16 @@ import Accordion from "@/layouts/components/Accordion.astro";
 import StatGroup from "@/layouts/components/StatGroup.astro";
 import Stat from "@/layouts/components/Stat.astro";
 import Social from "@/layouts/components/Social.astro";
+import { getCanonicalFromAstroURL } from "@/lib/utils/canonical";
+
+const canonical = getCanonicalFromAstroURL(Astro.url);
 ---
 
 <Base
   title="About CloudCredits.io - Open Source Startup Credits Directory"
   meta_title="About CloudCredits.io - Community-Built Credits Vault"
   description="Learn about CloudCredits.io - the open-source, community-driven platform helping startups find cloud credits and SaaS deals. Zero affiliates, no ads, just helpful resources for builders."
+  canonical={canonical}
 >
   <PageHeader title="About" />
 

--- a/src/pages/deals/assistant.astro
+++ b/src/pages/deals/assistant.astro
@@ -5,6 +5,7 @@ import AIInput from "@/layouts/components/AIInput";
 import PageHeader from "@/partials/PageHeader.astro";
 import AssistantClient from "@/layouts/components/AssistantClient";
 import { isFeatureEnabled } from "@/lib/featureFlags";
+import { getCanonicalFromAstroURL } from "@/lib/utils/canonical";
 
 // Check if Ask AI feature is enabled
 const askAIEnabled = isFeatureEnabled("askAI");
@@ -17,12 +18,15 @@ if (!askAIEnabled) {
 // Get all programs and providers from the content collection for client-side matching
 const allPrograms = await getCollection("programs");
 const allProviders = await getCollection("providers");
+
+const canonical = getCanonicalFromAstroURL(Astro.url);
 ---
 
 <Base
   title="Ask AI Assistant - Find Best Startup Credits & Deals"
   meta_title="AI Assistant for Startup Credits | CloudCredits.io"
   description="Ask our AI assistant to find the perfect cloud credits and startup deals for your specific needs. Get personalized recommendations from 150+ verified programs."
+  canonical={canonical}
 >
   <PageHeader title="Ask AI" />
 

--- a/src/pages/deals/index.astro
+++ b/src/pages/deals/index.astro
@@ -6,6 +6,7 @@ import ProgramCard from "@/layouts/components/ProgramCard.astro";
 import StatGroup from "@/components/StatGroup.astro";
 import Stat from "@/components/Stat.astro";
 import { FaFilter } from "react-icons/fa";
+import { getCanonicalFromAstroURL } from "@/lib/utils/canonical";
 
 // Get all programs and providers
 const allPrograms = await getCollection("programs");
@@ -37,12 +38,15 @@ const allTags = [
 
 // Sort tags alphabetically
 allTags.sort();
+
+const canonical = getCanonicalFromAstroURL(Astro.url);
 ---
 
 <Base
   title="Startup Deals & Cloud Credits - CloudCredits.io"
   meta_title="150+ Free Cloud Credits & Startup Deals | CloudCredits.io"
   description="Browse 150+ verified startup deals: AWS credits, Google Cloud, Azure, MongoDB, GitHub, Notion discounts. Filter by tags, value, and eligibility. Updated daily by community."
+  canonical={canonical}
 >
   <PageHeader title="Deals" />
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -6,6 +6,7 @@ import { getCollection } from "astro:content";
 import ProgramCard from "@/layouts/components/ProgramCard.astro";
 import { motion } from "framer-motion";
 import { isFeatureEnabled } from "@/lib/featureFlags";
+import { getCanonicalFromAstroURL } from "@/lib/utils/canonical";
 
 const allPrograms = await getCollection("programs");
 const featuredProgramTitles = [
@@ -21,12 +22,14 @@ const featuredPrograms = allPrograms.filter((p) =>
 );
 const rotationAngles = [-3, -1, 2, 1, -2, 3];
 const askAIEnabled = isFeatureEnabled("askAI");
+const canonical = getCanonicalFromAstroURL(Astro.url);
 ---
 
 <Base
   title="CloudCredits.io - Community Vault of Startup Credits & Deals"
   meta_title="CloudCredits.io - Free Cloud Credits Vault for Startups"
   description="Discover 150+ startup credits and cloud deals worth $1M+. Open-source vault of AWS, Google Cloud, Azure credits, SaaS discounts, and founder deals. No ads, no affiliates."
+  canonical={canonical}
 >
   <AnimatedBackground client:load />
   <div class="relative flex items-center justify-center min-h-screen">

--- a/src/pages/privacy-policy.astro
+++ b/src/pages/privacy-policy.astro
@@ -1,12 +1,16 @@
 ---
 import Base from "@/layouts/Base.astro";
 import PageHeader from "@/partials/PageHeader.astro";
+import { getCanonicalFromAstroURL } from "@/lib/utils/canonical";
+
+const canonical = getCanonicalFromAstroURL(Astro.url);
 ---
 
 <Base
   title="Privacy Policy - CloudCredits.io"
   meta_title="Privacy Policy - Zero Data Collection | CloudCredits.io"
   description="CloudCredits.io privacy policy: We collect zero personal data, use no analytics or tracking cookies, and don't sell information. Learn about our commitment to user privacy."
+  canonical={canonical}
 >
   <PageHeader title="Privacy Policy" />
 

--- a/src/pages/providers/[provider]/programs/[program].astro
+++ b/src/pages/providers/[provider]/programs/[program].astro
@@ -16,6 +16,7 @@ import Accordion from "@/components/Accordion.astro";
 import ProgramStatusIndicator from "@/layouts/components/ProgramStatusIndicator.astro";
 import Breadcrumbs from "@/layouts/components/Breadcrumbs.astro";
 import AnimatedBackground from "@/layouts/components/AnimatedBackground";
+import { getCanonicalFromAstroURL } from "@/lib/utils/canonical";
 
 export async function getStaticPaths() {
   const programs = await getCollection("programs");
@@ -329,6 +330,8 @@ const logo = miniSvgExists
     : pngExists
       ? pngLogo
       : svgLogo;
+
+const canonical = getCanonicalFromAstroURL(Astro.url);
 ---
 
 <Base
@@ -338,6 +341,7 @@ const logo = miniSvgExists
   image={logo}
   searchable
   search_collection="programs"
+  canonical={canonical}
 >
   <div class="relative min-h-screen" data-pagefind-meta={`image:${logo}`}>
     <!-- Replace gradient background with AnimatedBackground -->

--- a/src/pages/providers/[single].astro
+++ b/src/pages/providers/[single].astro
@@ -9,6 +9,7 @@ import { getCollection } from "astro:content";
 import Breadcrumbs from "@/layouts/components/Breadcrumbs.astro";
 import LogoSpot from "@/components/LogoSpot.tsx";
 import "@/styles/logo-spot.css";
+import { getCanonicalFromAstroURL } from "@/lib/utils/canonical";
 
 // get all static paths for providers
 export async function getStaticPaths() {
@@ -95,6 +96,8 @@ const logo = miniSvgExists
     : pngExists
       ? pngLogo
       : svgLogo;
+
+const canonical = getCanonicalFromAstroURL(Astro.url);
 ---
 
 <Base
@@ -104,6 +107,7 @@ const logo = miniSvgExists
   image={logo}
   searchable
   search_collection="providers"
+  canonical={canonical}
 >
   <section class="relative min-h-screen" data-pagefind-meta={`image:${logo}`}>
     <!-- Content -->

--- a/src/pages/providers/index.astro
+++ b/src/pages/providers/index.astro
@@ -5,6 +5,7 @@ import PageHeader from "@/partials/PageHeader.astro";
 import ProviderCard from "@/components/ProviderCard.astro";
 import StatGroup from "@/components/StatGroup.astro";
 import Stat from "@/components/Stat.astro";
+import { getCanonicalFromAstroURL } from "@/lib/utils/canonical";
 
 const providers = await getCollection("providers");
 const activeProviders = providers.filter((provider) => provider.data.active);
@@ -14,12 +15,15 @@ const allPrograms = await getCollection("programs");
 const activePrograms = allPrograms.filter(
   (program) => program.data.status === "Active",
 );
+
+const canonical = getCanonicalFromAstroURL(Astro.url);
 ---
 
 <Base
   title="Cloud Providers & SaaS Companies - CloudCredits.io"
   meta_title="Top Cloud Providers Offering Startup Credits | CloudCredits.io"
   description="Discover 50+ cloud providers and SaaS companies offering startup credits: AWS, Google Cloud, Azure, MongoDB, Stripe, and more. Find the best deals for your startup's stack."
+  canonical={canonical}
 >
   <PageHeader title="Providers" />
   <div class="container mt-8">

--- a/src/pages/roadmap.astro
+++ b/src/pages/roadmap.astro
@@ -4,6 +4,7 @@ import PageHeader from "@/partials/PageHeader.astro";
 import GrainBackground from "@/layouts/components/GrainBackground.astro";
 import config from "@/config/config.json";
 import { AnimatedRoadmap } from "@/layouts/components/AnimatedRoadmap";
+import { getCanonicalFromAstroURL } from "@/lib/utils/canonical";
 
 // Define roadmap items with categories and dates
 const functionalityItems = [
@@ -112,12 +113,15 @@ const roadmapItems = [...functionalityItems, ...contentItems].sort((a, b) => {
 // Use the teal color from the primary color palette for primary and a complementary color for secondary
 const primaryColor = config.theme.colors.primary.teal;
 const secondaryColor = config.theme.colors.primary.purple;
+
+const canonical = getCanonicalFromAstroURL(Astro.url);
 ---
 
 <Base
   title="CloudCredits.io Roadmap - Future Features & Development Plan"
   meta_title="CloudCredits.io Roadmap 2025 - AI Chat, Community Notes & More"
   description="See what's coming to CloudCredits.io: AI chat assistant with RAG, community notes, advanced filtering, 50+ new listings, and more features planned for 2025."
+  canonical={canonical}
 >
   <PageHeader title="Roadmap" />
 

--- a/src/pages/tags/[tag].astro
+++ b/src/pages/tags/[tag].astro
@@ -7,6 +7,7 @@ import PageHeader from "@/partials/PageHeader.astro";
 import ProgramCard from "@/layouts/components/ProgramCard.astro";
 import ProviderCard from "@/layouts/components/ProviderCard.astro";
 import { FaTag } from "react-icons/fa6";
+import { getCanonicalFromAstroURL } from "@/lib/utils/canonical";
 
 export async function getStaticPaths() {
   const tags = await getCombinedTags();
@@ -25,12 +26,15 @@ const { programs, providers } = await getItemsByTag(tag!);
 
 // Sort programs by date if available
 const sortedPrograms = sortByDate(programs);
+
+const canonical = getCanonicalFromAstroURL(Astro.url);
 ---
 
 <Base
   title={`${humanize(tag!)} Credits & Deals - CloudCredits.io`}
   meta_title={`Best ${humanize(tag!)} Startup Credits & Deals | CloudCredits.io`}
   description={`Find the best ${tag} credits and deals for startups. Discover verified programs with ${tag} services, including eligibility requirements and application steps.`}
+  canonical={canonical}
 >
   <div class="section pt-14">
     <div class="container">

--- a/src/pages/tags/index.astro
+++ b/src/pages/tags/index.astro
@@ -4,6 +4,7 @@ import { getCombinedTags, getAllTaxonomy } from "@/lib/taxonomyParser.astro";
 import { humanize } from "@/lib/utils/textConverter";
 import PageHeader from "@/partials/PageHeader.astro";
 import { FaTag } from "react-icons/fa6";
+import { getCanonicalFromAstroURL } from "@/lib/utils/canonical";
 
 // Get all unique tags
 const tags = await getCombinedTags();
@@ -12,12 +13,15 @@ const allTags = await getAllTaxonomy("programs", "tags");
 
 // Sort tags alphabetically
 tags.sort();
+
+const canonical = getCanonicalFromAstroURL(Astro.url);
 ---
 
 <Base
   title="Categories - Browse Cloud Credits by Tag | CloudCredits.io"
   meta_title="Startup Credits Categories - AWS, AI, Database & More"
   description="Browse cloud credits and startup deals by category: cloud infrastructure, AI/ML, databases, monitoring, security, and more. Find deals that match your tech stack."
+  canonical={canonical}
 >
   <PageHeader title={"Categories"} />
   <section class="section pt-4">


### PR DESCRIPTION
Fixes #372

Adds canonical tags to prevent duplicate content confusion and improve SEO signals consolidation:

- Create canonical URL utility function
- Add canonical tags to all major page types
- Follow site configuration for proper URL formatting
- Tested and verified in build output

Generated with [Claude Code](https://claude.ai/code)