### PR TITLE
Prepare repository for Hacktoberfest

### DIFF
--- a/.github/workflows/hacktoberfest-accepted.yml
+++ b/.github/workflows/hacktoberfest-accepted.yml
@@ -1,0 +1,15 @@
+name: Label PR as hacktoberfest-accepted on approval
+
+on:
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  label:
+    if: github.event.review.state == 'approved'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions-ecosystem/action-add-labels@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          labels: hacktoberfest-accepted

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,16 @@ Welcome! There are many ways to contribute—from writing code to adding program
 
 ---
 
+### Hacktoberfest Participation
+
+CloudCredits.io opts in to Hacktoberfest each year. To help contributions count:
+
+- Maintainers keep issues labeled with `hacktoberfest`, `good first issue`, and `help wanted` when they are ready for community pickup.
+- Reviewers merge qualifying work, leave an overall approving review, or apply the `hacktoberfest-accepted` label so your PR is accepted during the 7-day review window.
+- Please register at [hacktoberfest.com](https://hacktoberfest.com) before submitting October PRs, and avoid spammy or low-effort submissions—they will be marked `invalid` or `spam` per the event rules.
+
+---
+
 ### 1. Code Contributions
 
 - **Tech Stack**  

--- a/README.md
+++ b/README.md
@@ -34,6 +34,17 @@ CloudCredits.io is powered by AI agents that continually surface official startu
 
 We welcome pull requests that add new verified programs, improve data quality, or enhance the site experience. Please review the [contribution guidelines](CONTRIBUTING.md) before submitting changes or opening issues. Roadmap ideas are also tracked on the public [2025 roadmap](https://cloudcredits.io/roadmap).
 
+### Hacktoberfest 2025
+
+CloudCredits.io is participating in [Hacktoberfest 2025](https://hacktoberfest.com)! If you want your contributions to count toward the event:
+
+- **Register on hacktoberfest.com between September 15 and October 31.** Registration is required before contributing.
+- **Open non-draft PRs between October 1 and October 31** against public, unarchived repositories. Draft PRs do not count toward the challenge.
+- **Aim for six accepted PRs/MRs.** For 2025, completions require six PRs that are merged, receive an overall approving review, or are labeled `hacktoberfest-accepted`. Each accepted PR levels up your official Holopin digital badge after the 7-day review window (which can extend into November).
+- **Avoid spammy PRs.** Submitting two or more spam or invalid PRs can disqualify you from the event.
+
+To make participation easier, maintainers highlight contributor-friendly tasks with the `hacktoberfest`, `good first issue`, and `help wanted` labels and keep the `hacktoberfest` topic on this repository throughout the event. When your PR is ready, we will merge it, leave an approving review, or add the `hacktoberfest-accepted` label so it counts toward your progress. If you need help getting started, join the [Discord](https://discord.gg/h5FYzCb6aa) and say hello!
+
 ## Local Development
 
 This project uses [Astro](https://astro.build/) and is managed with [pnpm](https://pnpm.io/).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,15 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+The CloudCredits.io team takes security seriously. If you discover a vulnerability, please email **security@t3sh.com** with the details. Include steps to reproduce, potential impact, and any suggested mitigations. We will acknowledge receipt within 3 business days and aim to provide an initial response within 7 business days.
+
+Please do not open a public issue for security vulnerabilities. If you need to encrypt your report, request our PGP key in your initial message.
+
+## Scope
+
+This policy covers the CloudCredits.io website, infrastructure, and all code in this repository. Third-party services we rely on should be reported directly to the service provider.
+
+## Disclosure
+
+We follow a coordinated disclosure approach. Once a fix is available, we will credit you (if desired) and publish a summary of the issue and remediation steps.


### PR DESCRIPTION
## Summary
- add a Hacktoberfest 2025 participation guide to the README and contribution guide
- document coordinated security reporting expectations in a new SECURITY.md
- automate the `hacktoberfest-accepted` label when PRs receive an approving review

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7ab2a9460833396a0af2ccb0af686